### PR TITLE
nodeload is no longer a valid GitHub subdomain

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": {"name": "Michael Nutt", "url": "http://nuttnet.net"},
   "repository": {"type": "git", "url": "http://github.com/mnutt/oauth-proxy.git"},
   "dependencies": {
-    "everyauth":   "http://nodeload.github.com/bnoguchi/everyauth/tarball/master",
+    "everyauth":   "https://github.com/bnoguchi/everyauth/tarball/master",
     "http-proxy":  "0.8.0",
     "express":     "2.5.11",
     "connect":     "1.8.5",


### PR DESCRIPTION
Downloads against nodeload.github.com fail hard.
