### PR TITLE
Only load modules if configured

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,8 +12,12 @@ var proxy = new Proxy(conf.proxyTo.host, conf.proxyTo.port);
 var proxyMiddleware = proxy.middleware();
 
 // Set up our auth strategies
-github.setup(everyauth);
-google.setup(everyauth);
+if (conf.modules.github) {
+  github.setup(everyauth);
+}
+if (conf.modules.google) {
+  google.setup(everyauth);
+}
 
 function userCanAccess(req) {
   var auth = req.session.auth;


### PR DESCRIPTION
If we don't configure GitHub and Google, the app fails to load. This solves that.
