### PR TITLE
set host header for proxied request

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,4 +1,5 @@
 var httpProxy = require('http-proxy');
+var conf = require('../conf');
 
 var Proxy = module.exports = function(host, port) {
   this.host = host;
@@ -10,6 +11,9 @@ Proxy.prototype.middleware = function() {
   var self = this;
 
   return function (req, res, next) {
+    // need to set target host or we always get proxyTo's default vhost
+    req.headers['host'] = conf.proxyTo.host;
+
     self.proxy.proxyRequest(req, res, {
       host: self.host,
       port: self.port


### PR DESCRIPTION
currently, this is wrong when the origin vhost we want has a different name
from the `hostname` we're configured to use.
### Example
1. doorman is running at `private.host.com`, and is proxying requests back to `app.host.com`
2. after auth/authz, the request to the origin server has a header `Host: private.host.com`
3. the origin is unable to connect this request to the correct virtual host and serves the wrong content
