### PR TITLE
Add ability to control how the duration of the session cookie

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,8 @@ function loginPage(req, res, next) {
 }
 
 // Store the middleware since we use it in the websocket proxy
-var connectSession = connect.session({secret: conf.sessionSecret,
+var connectSession = connect.session({cookie: { maxAge: conf.sessionCookieMaxAge },
+                                      secret: conf.sessionSecret,
                                       fingerprint: function(req) { return "default"; }});
 
 var app = express.createServer(

--- a/conf.example.js
+++ b/conf.example.js
@@ -9,6 +9,7 @@ module.exports = {
   },
 
   sessionSecret: 'AeV8Thaieel0Oor6shainu6OUfoh3ohwZaemohC0Ahn3guowieth2eiCkohhohG4', // change me
+  sessionCookieMaxAge: 60 * 60 * 4 * 1000, // milliseconds until session cookie expires (or "false" to not expire)
 
   modules: {
     // Register a new oauth app on Github at


### PR DESCRIPTION
By default session cookies are only 4 hours.  We wanted to create a site that has a long-lived cookie so users would not have to constantly re-auth.

This pull request lets you configure the max age of the session used to store the auth token.
