### PR TITLE
Add ability to configure secureProxy for cookies to be sent only for SSL

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,6 +86,7 @@ function loginPage(req, res, next) {
 var sessionOptions = {
   maxage: conf.sessionCookieMaxAge,
   domain: conf.sessionCookieDomain,
+  secureProxy: conf.sessionSecureProxy,
   secret: conf.sessionSecret,
   name: '__doorman',
 };

--- a/conf.example.js
+++ b/conf.example.js
@@ -9,6 +9,7 @@ module.exports = {
 
   sessionSecret: 'AeV8Thaieel0Oor6shainu6OUfoh3ohwZaemohC0Ahn3guowieth2eiCkohhohG4', // change me
   sessionCookieMaxAge: 4 * 24 * 60 * 60 * 1000, // milliseconds until session cookie expires (or "false" to not expire)
+  // sessionSecureProxy: true, // optional secureProxy to set cookie only over HTTPS, defaut is not set
   // sessionCookieDomain: '.example.com', // optional cookie domain, default is not set
 
   // Paths that bypass doorman and do not need any authentication.  Matches on the


### PR DESCRIPTION
Hi, would this be useful ? I understand that doorman can be hosted by it's own but there are some cases where doorman is behind a proxy
