### PR TITLE
Override the default everyauth authQueryParam to be online and auto as

### DIFF
--- a/lib/modules/google.js
+++ b/lib/modules/google.js
@@ -46,6 +46,7 @@ exports.setup = function(everyauth) {
     .appId(conf.modules.google.appId)
     .appSecret(conf.modules.google.appSecret)
     .scope('https://www.googleapis.com/auth/userinfo.email')
+    .authQueryParam({ access_type:'online', approval_prompt:'auto' })
     .findOrCreateUser( function (sess, accessToken, accessTokenExtra, googleUser) {
       return googleUser;
     })


### PR DESCRIPTION
there is no need for refresh tokens, and no need to force the user to
click when there's no permission changes
