### PR TITLE
Support for HTTPS

### DIFF
--- a/app.js
+++ b/app.js
@@ -157,6 +157,8 @@ if (conf.securePort && conf.ssl && conf.ssl.keyFile && conf.ssl.certFile) {
     cert: fs.readFileSync(conf.ssl.certFile)
   };
 
+  if (conf.ssl.caFile) options.ca = fs.readFileSync(conf.ssl.caFile);
+
   var httpsServer = https.createServer(options, app);
 
   upgradeWebsocket(httpsServer);

--- a/conf.example.js
+++ b/conf.example.js
@@ -27,7 +27,7 @@ module.exports = {
   // ssl: {
   //   keyFile: '/path/to/keyfile.key',
   //   certFile: '/path/to/certfile.crt'
-  //   caFile: '/path/to/cafile.crt'
+  //   // caFile: '/path/to/cafile.crt' // OPTIONAL: Intermediate CA certificate
   // }
 
   // Paths that bypass doorman and do not need any authentication.  Matches on the

--- a/conf.example.js
+++ b/conf.example.js
@@ -2,6 +2,12 @@ module.exports = {
   // port to listen on
   port: 8085,
 
+  // Secure port for HTTPS connections. SSL certificate options MUST be set when enabled.
+  // securePort: 443,
+
+  // Force Transport Layer Security (TLS). Secure port and SSL certificates must be set.
+  // forceTLS: true,
+
   // URL for OAuth callbacks, default autodetect
   // hostname: 'http://myhostname.example.com',
 
@@ -16,6 +22,13 @@ module.exports = {
     maxage: 4 * 24 * 60 * 60 * 1000, // milliseconds until expiration (or "false" to not expire)
     secret: 'AeV8Thaieel0Oor6shainu6OUfoh3ohwZaemohC0Ahn3guowieth2eiCkohhohG4' // change me
   },
+
+  // SSL certificates are required when securePort is set
+  // ssl: {
+  //   keyFile: '/path/to/keyfile.key',
+  //   certFile: '/path/to/certfile.crt'
+  //   caFile: '/path/to/cafile.crt'
+  // }
 
   // Paths that bypass doorman and do not need any authentication.  Matches on the
   // beginning of paths; for example '/about' matches '/about/me'.  Regexes are also supported.

--- a/middlewares/tls.js
+++ b/middlewares/tls.js
@@ -1,4 +1,4 @@
-var conf = require('../../conf');
+var conf = require('../conf');
 
 /**
  * Check whether Transport Layer Security (TLS) is forced in the config. If
@@ -6,7 +6,16 @@ var conf = require('../../conf');
  **/
 module.exports = function forceTLS(req, res, next) {
   if (conf.forceTLS && conf.securePort && !req.secure) {
-    return res.redirect(['https://', req.get('Host'), req.url].join(''));
+    var redirectPath = ['https://', req.hostname];
+
+    if (conf.securePort != 443) {
+      redirectPath.push(':');
+      redirectPath.push(conf.securePort);
+    }
+
+    redirectPath.push(req.url);
+
+    return res.redirect(301, redirectPath.join(''));
   }
   next();
 }

--- a/middlewares/tls.js
+++ b/middlewares/tls.js
@@ -1,0 +1,12 @@
+var conf = require('../../conf');
+
+/**
+ * Check whether Transport Layer Security (TLS) is forced in the config. If
+ * forceTLS option is set to true, redirect all unsecured HTTP traffic to HTTPS.
+ **/
+module.exports = function forceTLS(req, res, next) {
+  if (conf.forceTLS && conf.securePort && !req.secure) {
+    return res.redirect(['https://', req.get('Host'), req.url].join(''));
+  }
+  next();
+}


### PR DESCRIPTION
This PR adds support for HTTPS connections. HTTPS server can be enabled by setting the `securePort` (e.g. 443). You may also force users to use the secure connection by setting `forceTLS` to true.

### Configuration Options

| Key            | Type    | Description                                                                                           |
|----------------|:-------:|-------------------------------------------------------------------------------------------------------|
| `securePort`   | Integer | If set, enables HTTPS mode                                                                            |
| `forceTLS`     | Boolean | _Optional:_ If true, forces a 301 redirect to `https://` protocol if the request protocol is unsecure |
| `ssl.keyFile`  | String  | Required if `securePort` is set. Path to file containing private key (\*.key or \*.pem)               |
| `ssl.certFile` | String  | Required if `securePort` is set. Path to file containing certificate (\*.crt or \*.pem)               |
| `ssl.caFile`   | String  | _Optional:_ Path to file containing Intermediate CA certificate (\*.crt or \*.pem)                    |