### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM odise/busybox-node
+
+ADD . /doorman
+WORKDIR /doorman
+
+RUN npm install
+EXPOSE 8085
+
+CMD [ "node", "app.js" ]


### PR DESCRIPTION
Attached Dockerfile allows to create small docker image (~50 MB) that runs doorman. It's quite useful if you run multiple microservices using docker and you want integrate docker into your environment.