### PR TITLE
Bump up version of http-proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express-flash":  "0.0.2",
     "everyauth":      "0.4.9",
     "express":        "4.8.8",
-    "http-proxy":     "1.3.0",
+    "http-proxy":     "1.11.1",
     "jade":           "1.6.0"
   },
   "bugs": {


### PR DESCRIPTION
I managed to track down issue #32,  it was simply a matter of bumping up the version of http-proxy. I don't know the details of why but it seems it does not play well with util.inherits.