### PR TITLE
Dockerfile initial version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node
+
+ADD . /doorman
+
+RUN \
+  cd /doorman && \
+  npm install && \
+  mv conf.environment.js conf.js
+
+WORKDIR /doorman
+
+ENTRYPOINT [ "npm", "start" ]


### PR DESCRIPTION
Solves movableink/doorman#31
See also movableink/doorman#30

How to test:

```
$ docker build -t=doorman . # Builds the Docker image locally
$ docker run -d --name=doorman_test_backend pataquets/drupal # Spin up a local test backend (Drupal 7).
$ docker run -d -p 8080:80 -e DOORMAN_LISTEN_PORT=80 -e DOORMAN_MODULES=password -e DOORMAN_PASSWORD_TOKEN=1234 -e DOORMAN_HOSTNAME=http://your.hostname.com:8080 -e DOORMAN_PROXY_HOST=backend -e DOORMAN_PROXY_PORT=80 --link=doorman_test_backend:backend --name=doorman_test_proxy doorman # Launches exposed Doorman (tip: use SQLite to finish Drupal install)
```
