### PR TITLE
As a convenience, send google the 'hd' parameter representing which domain to restrict sign-in to

### DIFF
--- a/lib/modules/google.js
+++ b/lib/modules/google.js
@@ -66,6 +66,8 @@ exports.setup = function(everyauth) {
     })
     .redirectPath('/');
 
+  if(requiredDomain) { everyauth.google.authQueryParam({ hd: requiredDomain}); }
+
   everyauth.google.authorize = function(auth) {
     if(requiredEmail) { if(!checkEmail(auth)) { return false; }; }
     if(requiredDomain) { if(!checkDomain(auth)) { return false }; }


### PR DESCRIPTION
Only set when `requiredDomain` is configured.

NB: As per official documentation from Google, you still need to check that the returned user
is indeed belonging to the `requiredDomain` which is code already present.