### PR TITLE
Pass X-Remote-User to backend

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,6 +39,7 @@ function userCanAccess(req) {
 
   for(var authType in auth) {
     if(everyauth[authType] && everyauth[authType].authorize(auth)) {
+      everyauth[authType].decorate(req, auth);
       return true;
     }
   }

--- a/lib/modules/github.js
+++ b/lib/modules/github.js
@@ -79,6 +79,9 @@ exports.setup = function(everyauth) {
 
     return true;
   };
+  everyauth.github.username = function(req, auth) {
+    req.username = auth.github.user.email;
+  };
   everyauth.github.title = "Github";
 
   if(requiredOrganization) {

--- a/lib/modules/github.js
+++ b/lib/modules/github.js
@@ -79,7 +79,7 @@ exports.setup = function(everyauth) {
 
     return true;
   };
-  everyauth.github.username = function(req, auth) {
+  everyauth.github.decorate = function(req, auth) {
     req.username = auth.github.user.email;
   };
   everyauth.github.title = "Github";

--- a/lib/modules/google.js
+++ b/lib/modules/google.js
@@ -72,6 +72,9 @@ exports.setup = function(everyauth) {
 
     return true;
   };
+  everyauth.google.decorate = function(req, auth) {
+    req.username = auth.google.user.email;
+  };
   everyauth.google.title = "Google";
 
   if(requiredDomain) {

--- a/lib/modules/password.js
+++ b/lib/modules/password.js
@@ -34,6 +34,9 @@ exports.setup = function(everyauth) {
   everyauth.password._entryPath = "/_doorman/login";
   everyauth.password.title = "Password";
   everyauth.password.authorize = hasSession;
+  everyauth.password.decorate = function(req, auth) {
+    req.username = 'user';
+  };
 
   log.warn("Registered password authentication.");
 };

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -7,6 +7,10 @@ var Proxy = module.exports = function(host, port) {
   this.port = port;
   this.target = "http://" + this.host + ":" + this.port;
   this.proxy = httpProxy.createProxyServer({xfwd: true});
+
+  this.proxy.on('proxyReq', function(proxyReq, req, res, options) {
+    proxyReq.setHeader('X-Remote-User', req.username);
+  });
 };
 
 Proxy.prototype.middleware = function() {

--- a/package.json
+++ b/package.json
@@ -14,22 +14,27 @@
     "url": "http://github.com/movableink/doorman.git"
   },
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "test": "./node_modules/.bin/mocha tests/*_spec.js"
   },
   "dependencies": {
-    "body-parser":    "1.8.0",
+    "body-parser": "1.8.0",
     "cookie-session": "1.0.2",
-    "cookie-parser":  "1.3.3",
-    "express-flash":  "0.0.2",
-    "everyauth":      "0.4.9",
-    "express":        "4.8.8",
-    "http-proxy":     "1.11.1",
-    "jade":           "1.6.0"
+    "cookie-parser": "1.3.3",
+    "express-flash": "0.0.2",
+    "everyauth": "0.4.9",
+    "express": "4.8.8",
+    "http-proxy": "1.11.1",
+    "jade": "1.6.0"
   },
   "bugs": {
     "url": "https://github.com/movableink/doorman/issues"
   },
   "main": "app.js",
-  "devDependencies": {},
+  "devDependencies": {
+    "chai": "3.4.1",
+    "mocha": "2.3.4",
+    "supertest": "1.1.0"
+  },
   "license": "MIT"
 }

--- a/tests/proxy_spec.js
+++ b/tests/proxy_spec.js
@@ -1,0 +1,38 @@
+var expect = require('chai').expect;
+var http = require('http');
+var Proxy = require('../lib/proxy');
+var supertest = require('supertest')
+
+describe('proxy', function() {
+    it('should pass remote user', function(done) {
+        var backend = http.createServer();
+
+        backend.on('request', function(req, res) {
+            expect(req.headers).to.have.property('x-remote-user');
+            expect(req.headers['x-remote-user']).to.equal('username');
+            backend.close();
+            done();
+        });
+        backend.on('error', function(err) {
+            backend.close();
+            done(err);
+        });
+        backend.listen(8080, function() {
+
+            var proxy = new Proxy('localhost', 8080);
+            var protagonist = proxy.middleware();
+
+            var frontend = http.createServer(
+                function(req, res, next) {
+                    req.username = 'username';
+                    return protagonist(req, res, next);
+                });
+            supertest(frontend).get('/foo')
+            .expect(200)
+            .then(function(res) {
+                // Just to provoke call
+            });
+
+        });
+    })
+})


### PR DESCRIPTION
Allows authentication modules to supply a username that gets passed to proxied service via X-Remote-User header.