### PR TITLE
Padding Oracle Vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ delegate your internal app's authentication/authorization to that app?
 Requirements
 ------------
 
- * node.js >= 0.10.x
+ * node.js >= 4.4.4 (Earlier versions are susceptible to [CVE-2016-2107](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2107)
 
 
 Installation

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ var flash      = require('express-flash');
 var everyauth  = require('everyauth');
 var Domain     = require('./lib/domain');
 var log        = require('./middlewares/log');
+var constants  = require('constants');
 
 var domains = {};
 
@@ -99,6 +100,8 @@ console.warn("Doorman on duty, listening on port " + config.port + ".");
 
 if(config.securePort) {
   var options = {
+    secureProtocol: 'SSLv23_method',
+    secureOptions: constants.SSL_OP_NO_SSLv3 | constants.SSL_OP_NO_SSLv2,
     key: fs.readFileSync(config.ssl.keyFile),
     cert: fs.readFileSync(config.ssl.certFile)
   };


### PR DESCRIPTION
* Fix POODLE vulnerability by disabling SSLv2 and SSLv3
* CVE-2016-2107 (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2107) is mitigated by upgrading to Node.js >=4.4.4