### PR TITLE
Fix crash if username not present in request

### DIFF
--- a/conf.environment.js
+++ b/conf.environment.js
@@ -13,6 +13,8 @@ var conf = {
     port: process.env.DOORMAN_PROXY_PORT
   },
 
+  addRobotsHeader: process.env.DOORMAN_ROBOTS_HEADER === 'true' ? true : false,
+
   // Session cookie options, see: https://github.com/expressjs/cookie-session
   sessionCookie: {
     name: '__doorman',
@@ -24,11 +26,20 @@ var conf = {
   // beginning of paths; for example '/about' matches '/about/me'.
   // example: DOORMAN_PUBLIC_PATHS="/about/,/robots.txt"
   publicPaths: process.env.DOORMAN_PUBLIC_PATHS && process.env.DOORMAN_PUBLIC_PATHS.split(',').map((path) => {
+    // If regular expresion filter is not present do not process
+    if (path.indexOf('|reg') !== -1) {  
+      return path;
+    } else {
+      path = path.replace('|reg', '');
+    }
+    // otherwise assume its valid until proven guilty
     let isValid = true;
     let expression = null;
     try {
+      // try to instantiate regular expression object 
       expression = new RegExp(path);
     } catch(e) {
+        // if exception was thrown it must be not valid expression
         isValid = false;
     }
     return isValid ? expression : path;

--- a/conf.environment.js
+++ b/conf.environment.js
@@ -27,7 +27,7 @@ var conf = {
   // example: DOORMAN_PUBLIC_PATHS="/about/,/robots.txt"
   publicPaths: process.env.DOORMAN_PUBLIC_PATHS && process.env.DOORMAN_PUBLIC_PATHS.split(',').map((path) => {
     // If regular expresion filter is not present do not process
-    if (path.indexOf('|reg') !== -1) {  
+    if (path.indexOf('|reg') === -1) {  
       return path;
     } else {
       path = path.replace('|reg', '');

--- a/conf.environment.js
+++ b/conf.environment.js
@@ -20,10 +20,19 @@ var conf = {
     secret: process.env.DOORMAN_SECRET || require('crypto').randomBytes(64).toString('hex') // if secret isn't supplied, generate a new one every start
   },
 
-  // Paths that bypass doorman and do not need any authentication.  Matches on the
-  // beginning of paths; for example '/about' matches '/about/me'.  Regexes are not supported from environment variables.
+  // Paths that bypass doorman and do not need any authentication. Matches on the
+  // beginning of paths; for example '/about' matches '/about/me'.
   // example: DOORMAN_PUBLIC_PATHS="/about/,/robots.txt"
-  publicPaths: process.env.DOORMAN_PUBLIC_PATHS && process.env.DOORMAN_PUBLIC_PATHS.split(','),
+  publicPaths: process.env.DOORMAN_PUBLIC_PATHS && process.env.DOORMAN_PUBLIC_PATHS.split(',').map((path) => {
+    let isValid = true;
+    let expression = null;
+    try {
+      expression = new RegExp(path);
+    } catch(e) {
+        isValid = false;
+    }
+    return isValid ? expression : path;
+  }),
 
   modules: {} // populated individually below
 };

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -9,7 +9,9 @@ var Proxy = module.exports = function(host, port) {
   this.proxy = httpProxy.createProxyServer({xfwd: true});
 
   this.proxy.on('proxyReq', function(proxyReq, req, res, options) {
-    proxyReq.setHeader('X-Remote-User', req.username);
+    if (req.username) {
+      proxyReq.setHeader('X-Remote-User', req.username);
+    }
   });
 };
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -12,6 +12,9 @@ var Proxy = module.exports = function(host, port) {
     if (req.username) {
       proxyReq.setHeader('X-Remote-User', req.username);
     }
+    if (conf.addRobotsHeader) {
+      proxyReq.setHeader('X-Robots-Tag', 'noindex, follow');
+    }
   });
 };
 


### PR DESCRIPTION
If we happen to request public path via doorman proxy servers crashes. It is caused by the event handler (* proxyReq*) which expects username in the request object which is not provided in that case.