### PR TITLE
Add authentication by Github team

### DIFF
--- a/config/domains/default.js.example
+++ b/config/domains/default.js.example
@@ -49,7 +49,7 @@ module.exports = {
       requiredOrganization: 'YOUR-ORGANIZATION-NAME' // short organization name
 
       // List of github teams that can authenticate
-      // requiredTeam: ['developers']
+      // requiredTeam: ['org/team']
     },
 
     // Simple password login, make sure you choose a very secure password.

--- a/config/domains/default.js.example
+++ b/config/domains/default.js.example
@@ -47,6 +47,9 @@ module.exports = {
       // Only users with this organization name can authenticate. If an array is
       // listed, user may authenticate as a member of ANY of the domains.
       requiredOrganization: 'YOUR-ORGANIZATION-NAME' // short organization name
+
+      // List of github teams that can authenticate
+      // requiredTeam: ['developers']
     },
 
     // Simple password login, make sure you choose a very secure password.

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -6,7 +6,7 @@ const http = require("http");
 const Router = require("express").Router;
 const passport = require("passport");
 const rp = require("request-promise-native");
-const crypto = require('crypto');
+const crypto = require("crypto");
 const LocalStrategy = require("passport-local-token").Strategy;
 const GitHubStrategy = require("passport-github").Strategy;
 const GoogleStrategy = require("passport-google-oauth").OAuth2Strategy;
@@ -26,9 +26,14 @@ const verifyGitHubOrganization = (valids, profile) => {
   return orgs.some(org => valids.includes(org));
 };
 
+const verifyGitHubTeam = (valids, profile) => {
+  let teams = profile.teams;
+  return teams.some(team => valids.includes(team));
+};
+
 const safeCompare = (a, b) => {
   return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
-}
+};
 
 class ProxyDomain {
   constructor(options) {
@@ -120,7 +125,11 @@ class ProxyDomain {
     passport.use(
       `${this.options.domain}-local`,
       new LocalStrategy({ tokenField: "password" }, function(token, cb) {
-        if (config.token && config.token.length === token.length && safeCompare(config.token, token)) {
+        if (
+          config.token &&
+          config.token.length === token.length &&
+          safeCompare(config.token, token)
+        ) {
           log.info("Authenticated with password login");
           return cb(null, { password: { authenticated: true } });
         } else {
@@ -142,9 +151,15 @@ class ProxyDomain {
     if (authorizedEmails && !Array.isArray(authorizedEmails)) {
       authorizedEmails = [authorizedEmails];
     }
-    if (!authorizedEmails && !authorizedOrganizations) {
-      log.error("Config must specify either requiredEmail or requiredOrganization.");
-      throw new Error("Config must specify either requiredEmail or requiredOrganization.");
+    let authorizedTeams = config.requiredTeam;
+    if (authorizedTeams && !Array.isArray(authorizedTeams)) {
+      authorizedTeams = [authorizedTeams];
+    }
+    if (!authorizedEmails && !authorizedOrganizations && !authorizedTeams) {
+      log.error("Config must specify one of requiredEmail, requiredOrganization, or requiredTeam.");
+      throw new Error(
+        "Config must specify one of requiredEmail, requiredOrganization or requiredTeam."
+      );
     }
 
     if (authorizedOrganizations) {
@@ -159,6 +174,13 @@ class ProxyDomain {
         this.options.domain +
           " registered GitHub authentication for users: " +
           authorizedEmails.join(", ")
+      );
+    }
+    if (authorizedTeams) {
+      log.info(
+        this.options.domain +
+          " regisitered GitHub authentication for teams: " +
+          authorizedTeams.join(", ")
       );
     }
 
@@ -186,6 +208,20 @@ class ProxyDomain {
             return done(err);
           }
 
+          try {
+            let teams = await rp({
+              json: true,
+              url: "https://api.github.com/user/teams",
+              headers: {
+                Authorization: `token ${accesstoken}`,
+                "User-Agent": "Doorman"
+              }
+            });
+            profile.teams = teams.map(team => team.name);
+          } catch (err) {
+            return done(err);
+          }
+
           let unauthorizedMessage = "Sorry, this account is not allowed to access this resource";
           // determine if the person being authenticated is in the allowed list of emails
           if (authorizedEmails) {
@@ -204,6 +240,15 @@ class ProxyDomain {
               log.info(
                 "User rejected because they aren't in the organization list: " +
                   authorizedOrganizations.join(", ")
+              );
+              return done(null, false, { message: unauthorizedMessage });
+            }
+          }
+          // determine if the person being authenticated is in the allowed list of teams
+          if (authorizedTeams) {
+            if (!verifyGitHubTeam(authorizedTeams, profile)) {
+              log.info(
+                "User rejected because they aren't in the team list: " + authorizedTeams.join(", ")
               );
               return done(null, false, { message: unauthorizedMessage });
             }

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -241,7 +241,7 @@ class ProxyDomain {
       router.get(
         "/oauth/google",
         passport.authenticate(`${this.options.domain}-google`, {
-          scope: "https://www.googleapis.com/auth/userinfo.email"
+          scope: "https://www.googleapis.com/auth/userinfo.email",
         })
       );
       router.get(
@@ -258,7 +258,9 @@ class ProxyDomain {
       let config = this.options.modules.github;
       router.get(
         config.entryPath,
-        passport.authenticate(`${this.options.domain}-github`, { scope: "user:email,read:org" })
+        passport.authenticate(`${this.options.domain}-github`, {
+          scope: "user:email,read:org" ,
+        })
       );
       router.get(
         config.callbackPath,
@@ -284,6 +286,11 @@ class ProxyDomain {
       );
     }
 
+    router.use((err, req, res, next) => {
+      req.flash("error", `The authentication method reports: ${err.message}`);
+      res.redirect("/");
+    })
+
     router(req, res, next);
   }
 
@@ -302,15 +309,11 @@ class ProxyDomain {
   }
 
   getCallbackProtocol() {
-    return this.isSecure() ? 'https://' : 'http://';
-  }
-
-  isSecure() {
-    return this.options.forceTLS && this.options.securePort;
+    return (this.options.forceTLS && this.options.securePort) ? 'https://' : 'http://';
   }
 
   tls(req, res, next) {
-    if (this.isSecure()) {
+    if (this.options.forceTLS && this.options.securePort && !req.secure) {
       let redirectPath = ["https://", req.hostname];
       redirectPath.push(req.url);
       return res.redirect(301, redirectPath.join(""));

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -24,7 +24,7 @@ const verifyEmail = (valids, profile) => {
 };
 
 const verifyGitHubOrganization = (valids, profile) => {
-  return verifyInclusion(valids, profile.organziations);
+  return verifyInclusion(valids, profile.organizations);
 };
 
 const verifyGitHubTeam = (valids, profile) => {
@@ -214,7 +214,7 @@ class ProxyDomain {
                 json: true,
                 url: "https://api.github.com/user/teams",
                 headers: {
-                  Authorization: `token ${accesstoken}`,
+                  Authorization: `token ${accessToken}`,
                   "User-Agent": "Doorman"
                 }
               });

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -200,18 +200,20 @@ class ProxyDomain {
           callbackURL: `${protocol}${this.options.domain}${config.callbackPath}`
         },
         async function(accessToken, refreshToken, profile, done) {
-          try {
-            let organizations = await rp({
-              json: true,
-              url: "https://api.github.com/user/orgs",
-              headers: {
-                Authorization: `token ${accessToken}`,
-                "User-Agent": "Doorman"
-              }
-            });
-            profile.organizations = organizations.map(org => org.login);
-          } catch (err) {
-            return done(err);
+          if (authorizedOrganizations) {
+            try {
+              let organizations = await rp({
+                json: true,
+                url: "https://api.github.com/user/orgs",
+                headers: {
+                  Authorization: `token ${accessToken}`,
+                  "User-Agent": "Doorman"
+                }
+              });
+              profile.organizations = organizations.map(org => org.login);
+            } catch (err) {
+              return done(err);
+            }
           }
 
           if (authorizedTeams) {

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -13,14 +13,20 @@ const GoogleStrategy = require("passport-google-oauth").OAuth2Strategy;
 
 const verifyInclusion = (valids, checks) => {
   return checks.some(check => valids.includes(check));
-}
+};
 
 const verifyEmailDomain = (valids, profile) => {
-  return verifyInclusion(valids, profile.emails.map(e => e.value.split("@")[1]));
+  return verifyInclusion(
+    valids,
+    profile.emails.map(e => e.value.split("@")[1])
+  );
 };
 
 const verifyEmail = (valids, profile) => {
-  return verifyInclusion(valids, profile.emails.map(e => e.value));
+  return verifyInclusion(
+    valids,
+    profile.emails.map(e => e.value)
+  );
 };
 
 const verifyGitHubOrganization = (valids, profile) => {
@@ -356,11 +362,19 @@ class ProxyDomain {
   }
 
   getCallbackProtocol() {
-    return (this.options.forceTLS && this.options.securePort) ? 'https://' : 'http://';
+    return this.secureDesired() ? "https://" : "http://";
+  }
+
+  secureDesired() {
+    return this.options.forceTLS && this.options.securePort;
+  }
+
+  isSecure(req) {
+    return this.secureDesired() && req && !req.secure;
   }
 
   tls(req, res, next) {
-    if (this.options.forceTLS && this.options.securePort && !req.secure) {
+    if (this.isSecure(req)) {
       let redirectPath = ["https://", req.hostname];
       redirectPath.push(req.url);
       return res.redirect(301, redirectPath.join(""));

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -13,14 +13,20 @@ const GoogleStrategy = require("passport-google-oauth").OAuth2Strategy;
 
 const verifyInclusion = (valids, checks) => {
   return checks.some(check => valids.includes(check));
-}
+};
 
 const verifyEmailDomain = (valids, profile) => {
-  return verifyInclusion(valids, profile.emails.map(e => e.value.split("@")[1]));
+  return verifyInclusion(
+    valids,
+    profile.emails.map(e => e.value.split("@")[1])
+  );
 };
 
 const verifyEmail = (valids, profile) => {
-  return verifyInclusion(valids, profile.emails.map(e => e.value));
+  return verifyInclusion(
+    valids,
+    profile.emails.map(e => e.value)
+  );
 };
 
 const verifyGitHubOrganization = (valids, profile) => {
@@ -349,15 +355,19 @@ class ProxyDomain {
   }
 
   getCallbackProtocol() {
-    return this.isSecure() ? 'https://' : 'http://';
+    return this.secureDesired() ? "https://" : "http://";
   }
 
-  isSecure() {
+  secureDesired() {
     return this.options.forceTLS && this.options.securePort;
   }
 
+  isSecure(req) {
+    return this.secureDesired() && req && !req.secure;
+  }
+
   tls(req, res, next) {
-    if (this.isSecure()) {
+    if (this.isSecure(req)) {
       let redirectPath = ["https://", req.hostname];
       redirectPath.push(req.url);
       return res.redirect(301, redirectPath.join(""));

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -12,7 +12,7 @@ const GitHubStrategy = require("passport-github").Strategy;
 const GoogleStrategy = require("passport-google-oauth").OAuth2Strategy;
 
 const verifyInclusion = (valids, checks) => {
-  return checks.some(check => valids.include(check));
+  return checks.some(check => valids.includes(check));
 }
 
 const verifyEmailDomain = (valids, profile) => {

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -158,7 +158,7 @@ class ProxyDomain {
     if (!authorizedEmails && !authorizedOrganizations && !authorizedTeams) {
       log.error("Config must specify one of requiredEmail, requiredOrganization, or requiredTeam.");
       throw new Error(
-        "Config must specify one of requiredEmail, requiredOrganization or requiredTeam."
+        "Config must specify one of requiredEmail, requiredOrganization, or requiredTeam."
       );
     }
 

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -294,7 +294,7 @@ class ProxyDomain {
       router.get(
         "/oauth/google",
         passport.authenticate(`${this.options.domain}-google`, {
-          scope: "https://www.googleapis.com/auth/userinfo.email",
+          scope: "https://www.googleapis.com/auth/userinfo.email"
         })
       );
       router.get(
@@ -312,7 +312,7 @@ class ProxyDomain {
       router.get(
         config.entryPath,
         passport.authenticate(`${this.options.domain}-github`, {
-          scope: "user:email,read:org" ,
+          scope: "user:email,read:org"
         })
       );
       router.get(
@@ -342,7 +342,7 @@ class ProxyDomain {
     router.use((err, req, res, next) => {
       req.flash("error", `The authentication method reports: ${err.message}`);
       res.redirect("/");
-    })
+    });
 
     router(req, res, next);
   }
@@ -362,19 +362,15 @@ class ProxyDomain {
   }
 
   getCallbackProtocol() {
-    return this.secureDesired() ? "https://" : "http://";
+    return this.isSecure() ? "https://" : "http://";
   }
 
-  secureDesired() {
+  isSecure() {
     return this.options.forceTLS && this.options.securePort;
   }
 
-  isSecure(req) {
-    return this.secureDesired() && req && !req.secure;
-  }
-
   tls(req, res, next) {
-    if (this.isSecure(req)) {
+    if (this.isSecure() && !req.secure) {
       let redirectPath = ["https://", req.hostname];
       redirectPath.push(req.url);
       return res.redirect(301, redirectPath.join(""));

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -11,24 +11,24 @@ const LocalStrategy = require("passport-local-token").Strategy;
 const GitHubStrategy = require("passport-github").Strategy;
 const GoogleStrategy = require("passport-google-oauth").OAuth2Strategy;
 
+const verifyInclusion = (valids, checks) => {
+  return checks.some(check => valids.include(check));
+}
+
 const verifyEmailDomain = (valids, profile) => {
-  let emailDomains = profile.emails.map(e => e.value.split("@")[1]);
-  return emailDomains.some(domain => valids.includes(domain));
+  return verifyInclusion(valids, profile.emails.map(e => e.value.split("@")[1]));
 };
 
 const verifyEmail = (valids, profile) => {
-  let emails = profile.emails.map(e => e.value);
-  return emails.some(email => valids.includes(email));
+  return verifyInclusion(valids, profile.emails.map(e => e.value));
 };
 
 const verifyGitHubOrganization = (valids, profile) => {
-  let orgs = profile.organizations;
-  return orgs.some(org => valids.includes(org));
+  return verifyInclusion(valids, profile.organziations);
 };
 
 const verifyGitHubTeam = (valids, profile) => {
-  let teams = profile.teams;
-  return teams.some(team => valids.includes(team));
+  return verifyInclusion(valids, profile.teams);
 };
 
 const safeCompare = (a, b) => {

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -185,7 +185,7 @@ class ProxyDomain {
     if (authorizedTeams) {
       log.info(
         this.options.domain +
-          " regisitered GitHub authentication for teams: " +
+          " registered GitHub authentication for teams: " +
           authorizedTeams.join(", ")
       );
     }

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -208,18 +208,20 @@ class ProxyDomain {
             return done(err);
           }
 
-          try {
-            let teams = await rp({
-              json: true,
-              url: "https://api.github.com/user/teams",
-              headers: {
-                Authorization: `token ${accesstoken}`,
-                "User-Agent": "Doorman"
-              }
-            });
-            profile.teams = teams.map(team => team.name);
-          } catch (err) {
-            return done(err);
+          if (authorizedTeams) {
+            try {
+              let teams = await rp({
+                json: true,
+                url: "https://api.github.com/user/teams",
+                headers: {
+                  Authorization: `token ${accesstoken}`,
+                  "User-Agent": "Doorman"
+                }
+              });
+              profile.teams = teams.map(team => `${team.organization.login}/${team.name}`);
+            } catch (err) {
+              return done(err);
+            }
           }
 
           let unauthorizedMessage = "Sorry, this account is not allowed to access this resource";


### PR DESCRIPTION
We currently have the ability to limit Github authentication to organization membership or profile email address.  This PR adds the ability to authenticate by Github team membership.  It's built on top of the passport work replacing everyauth.

[ch33183]