### PR TITLE
Allow setting the callback protocol for services that are fronted wit…

### DIFF
--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -86,7 +86,7 @@ class ProxyDomain {
       );
     }
 
-    let protocol = this.getCallbackProtocol();
+    let protocol = config.callbackProtocol || this.getCallbackProtocol();
     passport.use(
       `${this.options.domain}-google`,
       new GoogleStrategy(
@@ -190,7 +190,7 @@ class ProxyDomain {
       );
     }
 
-    let protocol = this.getCallbackProtocol();
+    let protocol = config.callbackProtocol || this.getCallbackProtocol();
     passport.use(
       `${this.options.domain}-github`,
       new GitHubStrategy(


### PR DESCRIPTION
…h tls termination

This change allows directly setting the protocol for cases where we are using tls for domains but doorman is not handling tls termination.