### PR TITLE
Allow for a list of password tokens

### DIFF
--- a/config/domains/default.js.example
+++ b/config/domains/default.js.example
@@ -55,6 +55,8 @@ module.exports = {
     // Simple password login, make sure you choose a very secure password.
     // password: {
     //  token: "YOUR-PASSWORD" // any user that knows this can log in
+    //     -- or --
+    //  tokens: ["ONE-PASSWORD", "ANOTHER-PASSWORD"] // either of these can be used
     // },
 
     // Register a new oauth app on Google Apps at

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -131,12 +131,7 @@ class ProxyDomain {
     passport.use(
       `${this.options.domain}-local`,
       new LocalStrategy({ tokenField: "password" }, function(token, cb) {
-        let tokens;
-        if (config.token && config.token.length) {
-          tokens = [config.token];
-        } else {
-          tokens = config.tokens || [];
-        }
+        const tokens = config.token ? [config.token] : config.tokens || [];
 
         if (tokens.find(t => t.length && t.length == token.length && safeCompare(t, token))) {
           log.info("Authenticated with password login");

--- a/lib/proxy_domain.js
+++ b/lib/proxy_domain.js
@@ -131,11 +131,14 @@ class ProxyDomain {
     passport.use(
       `${this.options.domain}-local`,
       new LocalStrategy({ tokenField: "password" }, function(token, cb) {
-        if (
-          config.token &&
-          config.token.length === token.length &&
-          safeCompare(config.token, token)
-        ) {
+        let tokens;
+        if (config.token && config.token.length) {
+          tokens = [config.token];
+        } else {
+          tokens = config.tokens || [];
+        }
+
+        if (tokens.find(t => t.length && t.length == token.length && safeCompare(t, token))) {
           log.info("Authenticated with password login");
           return cb(null, { password: { authenticated: true } });
         } else {


### PR DESCRIPTION
[:house: [ch34419]](https://app.clubhouse.io/movableink/story/34419/multiple-password-support-for-doorman)

To allow multiple outsiders to each authenticate with their own password.

The `config.token.length` check is subsumed into the `find()` call; if `config.token === ""`, there will only be one element in the array and it will not match.