### PR TITLE
Fix domain reflection xss

### DIFF
--- a/middlewares/set_domain.js
+++ b/middlewares/set_domain.js
@@ -6,7 +6,7 @@ const setDomain = function(domains) {
     if (req.vdomain) {
       next();
     } else {
-      let cleanedDomain = host.replace(/[^A-Za-z0-9\-.:]/, "");
+      let cleanedDomain = host.replace(/[^A-Za-z0-9\-.:]/g, "");
       res.writeHead(500, {});
       res.end("Unrecognized domain " + cleanedDomain + " and no default domain set");
     }


### PR DESCRIPTION
The current implementation changes `"></A></ADDRESS>"><script>alert(document.domain)</script><ADDRESS><A "/xss/"` to `></A></ADDRESS>"><script>alert(document.domain)</script><ADDRESS><A "/xss/"`.  It should instead change it to `AADDRESSscriptalertdocument.domainscriptADDRESSAxss`.

[ch38573]